### PR TITLE
Fix review findings on the Payments Garage branch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,8 +18,11 @@
 VITE_ENABLE_JPMC=false
 
 # Dev-proxy targets (only used by `pnpm start`; the container uses nginx).
+# VITE_MOCKED_API_URL is the Local Mock tier; the two below both point at the
+# express server, which fronts the JPMC Mock and JPMC CAT tiers respectively.
 VITE_MOCKED_API_URL=http://localhost:8081
 VITE_CAT_API_URL=http://localhost:8082
+VITE_JPMC_MOCK_API_URL=http://localhost:8082
 
 # Credential headers sent to JPMC CAT (from your onboarding).
 VITE_CLIENT_ID=
@@ -46,3 +49,9 @@ SECRET_NAME=
 # Client certificates (do NOT commit). Local dev paths (relative to app/server):
 #   ../certs/jpmc.key, ../certs/jpmc.crt, ../certs/digital-signature/key.key
 # In the `server` container they are mounted at /certs (see compose.yaml).
+
+# Return internal error detail (cert paths, upstream OAuth failures) in HTTP
+# responses. Local debugging only - leave unset anywhere reachable by others.
+# Deliberately separate from NODE_ENV, which the container pins to
+# `development` so certs are read from the mounted ./certs.
+DEBUG_ERRORS=false

--- a/app/client/src/hooks/useApiHistory.ts
+++ b/app/client/src/hooks/useApiHistory.ts
@@ -52,10 +52,9 @@ export function useApiHistory<T extends ApiHistoryEntry>(
 
   const addEntry = (item: T) => setHistory((prev) => [item, ...prev]);
 
-  const clearHistory = () => {
-    setHistory([]);
-    localStorage.removeItem(storageKey);
-  };
+  // The save effect above persists the cleared list, so there is no separate
+  // removeItem here - it would be undone on the very next render.
+  const clearHistory = () => setHistory([]);
 
   const handleRowClick = (rowIndex: number) => {
     const selected = history[rowIndex];

--- a/app/client/src/mocks/handlers.test.ts
+++ b/app/client/src/mocks/handlers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { selectFXRates } from "./handlers";
+import { selectFXRates, triggeredErrorStatus } from "./handlers";
 import fxRateSheet from "./mockedJson/FXRateSheet.json";
 
 const sheet = fxRateSheet as Array<{ baseCurrency: string }>;
@@ -25,5 +25,31 @@ describe("selectFXRates (FX Rate Sheet mock)", () => {
     expect(first).toHaveProperty("guarenteedRateInd");
     expect(first).toHaveProperty("minTranSize");
     expect(first).toHaveProperty("maxTranSize");
+  });
+});
+
+const withTrigger = (value?: string) =>
+  new URL(
+    `https://unicorn.test/api/fxapi/v1/rate-sheets${
+      value === undefined ? "" : `?statusCode=${value}`
+    }`,
+  );
+
+describe("triggeredErrorStatus (?statusCode= error simulation)", () => {
+  it("returns null when no trigger is present", () => {
+    expect(triggeredErrorStatus(withTrigger())).toBeNull();
+  });
+
+  it("echoes the requested status rather than collapsing it to 500", () => {
+    // Regression: every handler used to answer ?statusCode=401 with a 500,
+    // which made the auth-failure path impossible to demo.
+    expect(triggeredErrorStatus(withTrigger("401"))).toBe(401);
+    expect(triggeredErrorStatus(withTrigger("500"))).toBe(500);
+  });
+
+  it("ignores statuses outside the simulatable set", () => {
+    expect(triggeredErrorStatus(withTrigger("418"))).toBeNull();
+    expect(triggeredErrorStatus(withTrigger("not-a-number"))).toBeNull();
+    expect(triggeredErrorStatus(withTrigger(""))).toBeNull();
   });
 });

--- a/app/client/src/mocks/handlers.ts
+++ b/app/client/src/mocks/handlers.ts
@@ -29,13 +29,32 @@ export function selectFXRates(
   return matched.length > 0 ? matched : all;
 }
 
+/**
+ * Error-simulation trigger shared by every handler: `?statusCode=<code>` makes
+ * the mock return that status instead of its happy-path payload. Kept in one
+ * place so a beat can't drift into answering 401 with a 500. Pure + exported so
+ * it can be unit-tested without spinning up the mock server.
+ */
+export const SIMULATABLE_ERROR_STATUSES = [401, 403, 404, 500] as const;
+
+export function triggeredErrorStatus(url: URL): number | null {
+  const requested = Number(url.searchParams.get("statusCode"));
+  return SIMULATABLE_ERROR_STATUSES.includes(
+    requested as (typeof SIMULATABLE_ERROR_STATUSES)[number],
+  )
+    ? requested
+    : null;
+}
+
 // Define handlers that catch the corresponding requests and returns the mock data.
 export const handlers = [
   http.post("/api/accessapi/balance", ({ request }) => {
     const url = new URL(request.url);
-    const statusCode = url.searchParams.get("statusCode");
-    if (statusCode === "500") {
-      return new HttpResponse(JSON.stringify(errorResponse), { status: 500 });
+    const errorStatus = triggeredErrorStatus(url);
+    if (errorStatus) {
+      return new HttpResponse(JSON.stringify(errorResponse), {
+        status: errorStatus,
+      });
     }
     return HttpResponse.json(
       { accountList: accountBalanceMockedResponse },
@@ -46,9 +65,11 @@ export const handlers = [
     "/api/digitalSignature/payment/v2/payments",
     async ({ request }) => {
       const url = new URL(request.url);
-      const statusCode = url.searchParams.get("statusCode");
-      if (statusCode === "401") {
-        return new HttpResponse(JSON.stringify(errorResponse), { status: 500 });
+      const errorStatus = triggeredErrorStatus(url);
+      if (errorStatus) {
+        return new HttpResponse(JSON.stringify(errorResponse), {
+          status: errorStatus,
+        });
       }
 
       // Parse request body to get requestId
@@ -71,9 +92,11 @@ export const handlers = [
   ),
   http.post("/api/tsapi/v2/validations/accounts", async ({ request }) => {
     const url = new URL(request.url);
-    const statusCode = url.searchParams.get("statusCode");
-    if (statusCode === "401") {
-      return new HttpResponse(JSON.stringify(errorResponse), { status: 500 });
+    const errorStatus = triggeredErrorStatus(url);
+    if (errorStatus) {
+      return new HttpResponse(JSON.stringify(errorResponse), {
+        status: errorStatus,
+      });
     }
     // Parse request body to get requestId
     let requestId = "default-request-id";
@@ -104,9 +127,11 @@ export const handlers = [
   }),
   http.post("/api/fxapi/v1/rate-sheets", async ({ request }) => {
     const url = new URL(request.url);
-    const statusCode = url.searchParams.get("statusCode");
-    if (statusCode === "401") {
-      return new HttpResponse(JSON.stringify(errorResponse), { status: 500 });
+    const errorStatus = triggeredErrorStatus(url);
+    if (errorStatus) {
+      return new HttpResponse(JSON.stringify(errorResponse), {
+        status: errorStatus,
+      });
     }
     const body = (await request.json()) as {
       accountId?: string;
@@ -133,9 +158,11 @@ export const handlers = [
   }),
   http.get("/api/tsapi/v3/transactions", ({ request }) => {
     const url = new URL(request.url);
-    const statusCode = url.searchParams.get("statusCode");
-    if (statusCode === "500") {
-      return new HttpResponse(JSON.stringify(errorResponse), { status: 500 });
+    const errorStatus = triggeredErrorStatus(url);
+    if (errorStatus) {
+      return new HttpResponse(JSON.stringify(errorResponse), {
+        status: errorStatus,
+      });
     }
     return HttpResponse.json(
       { transactions: transactionsMock },

--- a/app/client/vite-env.d.ts
+++ b/app/client/vite-env.d.ts
@@ -6,6 +6,7 @@ interface ImportMetaEnv {
   readonly VITE_PROGRAM_ID_TYPE?: string;
   readonly VITE_MOCKED_API_URL?: string;
   readonly VITE_CAT_API_URL?: string;
+  readonly VITE_JPMC_MOCK_API_URL?: string;
   // "true" unlocks the JPMC Sandbox / JPMC CAT tiers in the env switcher.
   readonly VITE_ENABLE_JPMC?: string;
 }

--- a/app/client/vite.config.mts
+++ b/app/client/vite.config.mts
@@ -1,34 +1,44 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import viteTsconfigPaths from "vite-tsconfig-paths";
 import svgrPlugin from "vite-plugin-svgr";
 import tailwindcss from "@tailwindcss/vite";
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react(), viteTsconfigPaths(), svgrPlugin(), tailwindcss()],
-  server: {
-    proxy: {
-      "/api": {
-        target: process.env.VITE_MOCKED_API_URL || "http://localhost:8081",
-        changeOrigin: true,
-        secure: false,
-        rewrite: (path) => path.replace(/^\/api/, ""),
-      },
-      "/cat-api": {
-        target: process.env.VITE_CAT_API_URL || "http://localhost:8082",
-        changeOrigin: true,
-        secure: false,
-        rewrite: (path) => path.replace(/^\/cat-api\/api/, ""),
-      },
-      "/mock-api": {
+export default defineConfig(({ mode }) => {
+  // Vite does not populate process.env from .env files inside this config, so
+  // the proxy targets below would always fall back to their defaults. Load the
+  // VITE_* vars explicitly so the values documented in .env.example take effect.
+  const env = loadEnv(mode, process.cwd(), "VITE_");
+
+  return {
+    plugins: [react(), viteTsconfigPaths(), svgrPlugin(), tailwindcss()],
+    server: {
+      proxy: {
+        // Local Mock tier. Only reached when MSW is disabled; MSW normally
+        // intercepts /api in the browser before it hits the network.
+        "/api": {
+          target: env.VITE_MOCKED_API_URL || "http://localhost:8081",
+          changeOrigin: true,
+          secure: false,
+          rewrite: (path) => path.replace(/^\/api/, ""),
+        },
+        // JPMC CAT tier -> express server (mTLS + signed JWT).
+        "/cat-api": {
+          target: env.VITE_CAT_API_URL || "http://localhost:8082",
+          changeOrigin: true,
+          secure: false,
+          rewrite: (path) => path.replace(/^\/cat-api\/api/, ""),
+        },
         // JPMC Mock tier -> express server, which mints the OAuth2 Bearer and
         // forwards to api-mock. Rewrites to the server's /mockapi mount.
-        target: process.env.VITE_MOCK_API_URL || "http://localhost:8082",
-        changeOrigin: true,
-        secure: false,
-        rewrite: (path) => path.replace(/^\/mock-api\/api/, "/mockapi"),
+        "/mock-api": {
+          target: env.VITE_JPMC_MOCK_API_URL || "http://localhost:8082",
+          changeOrigin: true,
+          secure: false,
+          rewrite: (path) => path.replace(/^\/mock-api\/api/, "/mockapi"),
+        },
       },
     },
-  },
+  };
 });

--- a/app/server/Dockerfile
+++ b/app/server/Dockerfile
@@ -8,6 +8,8 @@ RUN corepack enable
 COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY . .
+# development = read certs from the mounted ./certs rather than Secrets Manager.
+# It does NOT enable verbose errors; set DEBUG_ERRORS=true for that (see .env.example).
 ENV NODE_ENV=development
 EXPOSE 8082
 # app.local.js listens on :8082 and loads certs from ../certs (mounted).

--- a/app/server/app.js
+++ b/app/server/app.js
@@ -11,6 +11,11 @@ const { generateJWTJose } = require('./digitalSignature');
 
 // Constants for better maintainability
 const ENV = process.env.NODE_ENV || 'development';
+// Error verbosity is deliberately NOT tied to NODE_ENV. The server container
+// ships with NODE_ENV=development so certs are read from the mounted ./certs
+// rather than Secrets Manager - that must not also expose internal error
+// detail (cert paths, OAuth responses) to anyone who can reach the proxy.
+const DEBUG_ERRORS = process.env.DEBUG_ERRORS === 'true';
 const API_ENDPOINTS = {
   JPMORGAN_SANDBOX: 'https://api-sandbox.payments.jpmorgan.com',
   JPMORGAN_GATEWAY: 'https://apigatewaycat.jpmorgan.com',
@@ -164,18 +169,13 @@ function createProxyConfiguration(target, httpsOpts) {
 // --- JPMC Mock tier: OAuth2 client-credentials + Bearer proxy to api-mock ---
 
 let cachedToken = null; // { value, expiresAt }
+let inFlightToken = null; // shared by concurrent callers, cleared when settled
 
 /**
- * Fetches (and caches) an OAuth2 client-credentials Bearer token for PDP's Mock
- * environment. The client secret stays server-side and never reaches the browser.
- * @returns {Promise<string>} a valid access token
+ * Requests a fresh OAuth2 client-credentials token from PDP.
+ * @returns {Promise<{value: string, expiresAt: number}>}
  */
-const getMockAccessToken = async () => {
-  const now = Date.now();
-  if (cachedToken && cachedToken.expiresAt > now + 60000) {
-    return cachedToken.value;
-  }
-
+const requestMockAccessToken = async () => {
   const clientId = process.env.PDP_CLIENT_ID;
   const clientSecret = process.env.PDP_CLIENT_SECRET;
   if (!clientId || !clientSecret) {
@@ -192,6 +192,8 @@ const getMockAccessToken = async () => {
     client_secret: clientSecret,
   });
 
+  // Stamp before the round trip so expiry is measured conservatively.
+  const requestedAt = Date.now();
   const response = await fetch(PDP.TOKEN_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -199,32 +201,69 @@ const getMockAccessToken = async () => {
   });
 
   if (!response.ok) {
+    // The token endpoint echoes request detail back; log it, but keep it out of
+    // the Error so it can never reach a client via DEBUG_ERRORS.
     const text = await response.text();
-    throw new Error(`OAuth token request failed (${response.status}): ${text}`);
+    console.error(`OAuth token request failed (${response.status}): ${text}`);
+    throw new Error(`OAuth token request failed (${response.status})`);
   }
 
   const data = await response.json();
-  cachedToken = {
+  return {
     value: data.access_token,
-    expiresAt: now + Number(data.expires_in || 3600) * 1000,
+    expiresAt: requestedAt + Number(data.expires_in || 3600) * 1000,
   };
-  return cachedToken.value;
+};
+
+/**
+ * Returns a valid Bearer token for PDP's Mock environment, reusing the cached
+ * one until it is within a minute of expiry. Concurrent callers share a single
+ * in-flight request instead of each hitting the token endpoint. The client
+ * secret stays server-side and never reaches the browser.
+ * @returns {Promise<string>} a valid access token
+ */
+const getMockAccessToken = async () => {
+  if (cachedToken && cachedToken.expiresAt > Date.now() + 60000) {
+    return cachedToken.value;
+  }
+
+  if (!inFlightToken) {
+    inFlightToken = requestMockAccessToken()
+      .then((token) => {
+        cachedToken = token;
+        return token.value;
+      })
+      .finally(() => {
+        inFlightToken = null;
+      });
+  }
+
+  return inFlightToken;
 };
 
 /**
  * Proxy to PDP's Mock environment that attaches the OAuth2 Bearer token.
  * Standard TLS (no client certs) - auth is the Bearer, not mTLS.
+ *
+ * Built once at startup: creating one per request would allocate a fresh proxy
+ * server and agent on every call. The per-request token rides on `req` instead.
  */
-const createMockProxyConfiguration = (accessToken) =>
-  createProxyMiddleware({
-    target: PDP.API_MOCK,
-    changeOrigin: true,
-    on: {
-      proxyReq: (proxyReq) => {
-        proxyReq.setHeader('Authorization', `Bearer ${accessToken}`);
-      },
+const mockProxy = createProxyMiddleware({
+  target: PDP.API_MOCK,
+  changeOrigin: true,
+  on: {
+    proxyReq: (proxyReq, req) => {
+      proxyReq.setHeader('Authorization', `Bearer ${req.pdpAccessToken}`);
     },
-  });
+    proxyRes: (proxyRes) => {
+      // api-mock rejected the token (revoked early, or clock skew). Drop it so
+      // the next call mints a fresh one rather than reusing it until expiry.
+      if (proxyRes.statusCode === 401) {
+        cachedToken = null;
+      }
+    },
+  },
+});
 
 const routeRequest = (splat) => {
   if (splat.includes('payment')) {
@@ -242,15 +281,13 @@ const routeRequest = (splat) => {
 // /mockapi mount, and we forward <rest> to api-mock with a Bearer token.
 app.use('/mockapi', async (req, res, next) => {
   try {
-    const accessToken = await getMockAccessToken();
-    const proxyMiddleware = createMockProxyConfiguration(accessToken);
-    proxyMiddleware(req, res, next);
+    req.pdpAccessToken = await getMockAccessToken();
+    mockProxy(req, res, next);
   } catch (error) {
     console.error('JPMC Mock proxy error:', error);
     res.status(500).json({
       error: 'JPMC Mock unavailable',
-      message:
-        ENV === 'development' ? error.message : 'Mock tier not configured',
+      message: DEBUG_ERRORS ? error.message : 'Mock tier not configured',
     });
   }
 });
@@ -273,8 +310,7 @@ app.use('/digitalSignature/:splat', jsonParser, async (req, res, next) => {
     console.error('Error in catch-all route:', error);
     res.status(500).json({
       error: 'Internal server error',
-      message:
-        ENV === 'development' ? error.message : 'Proxy configuration failed',
+      message: DEBUG_ERRORS ? error.message : 'Proxy configuration failed',
     });
   }
 });
@@ -290,8 +326,7 @@ app.use('/:splat', async (req, res, next) => {
     console.error('Error in catch-all route:', error);
     res.status(500).json({
       error: 'Internal server error',
-      message:
-        ENV === 'development' ? error.message : 'Proxy configuration failed',
+      message: DEBUG_ERRORS ? error.message : 'Proxy configuration failed',
     });
   }
 });
@@ -301,7 +336,7 @@ app.use((error, req, res, _next) => {
   console.error('Unhandled error:', error);
   res.status(500).json({
     error: 'Internal server error',
-    message: ENV === 'development' ? error.message : 'Something went wrong',
+    message: DEBUG_ERRORS ? error.message : 'Something went wrong',
   });
 });
 

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -23,5 +23,10 @@
         "start:local": "NODE_ENV='development' nodemon app.local.js",
         "build": "zip archive.zip . -r -x \"/certs/**\" -x \"*/.DS_Store\" -x \"app.local.js\" -x \"/mock-server/**\""
     },
-    "license": "Apache-2.0"
+    "license": "Apache-2.0",
+    "pnpm": {
+        "overrides": {
+            "semver": "^6.3.1"
+        }
+    }
 }


### PR DESCRIPTION
Server Docker build was broken: package.json dropped the semver resolutions field while pnpm-lock.yaml kept the matching overrides block, so the Dockerfile's `pnpm install --frozen-lockfile` failed with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH and `docker compose --profile real up` could not build. Ported the pin to pnpm.overrides, which matches the existing lockfile exactly - the pin survives and the lockfile is untouched.

Error verbosity no longer keys off NODE_ENV. The container pins NODE_ENV=development so certs are read from the mounted ./certs, which also turned on internal error detail for anyone who could reach the proxy. Added a separate DEBUG_ERRORS flag, off by default. The OAuth token endpoint's response body is now logged server-side only and kept out of the thrown Error entirely, so it cannot leak even with DEBUG_ERRORS on.

Every mock handler answered ?statusCode=401 with an HTTP 500, making the auth-failure path impossible to demo. This predates the branch (payments and validations already had it; the new FX handler copied the pattern), so rather than patch the literals, the trigger mapping moved into a shared, exported triggeredErrorStatus helper that all five handlers call - with unit tests. Note this broadens each handler to the full trigger set (401/403/404/500) where each previously accepted only one.

The JPMC Mock proxy built a fresh proxy server and agent on every request; it is now constructed once at startup with the per-request token carried on req. A proxyRes hook clears the cached token on a 401 from api-mock so a revoked token self-heals instead of failing until its TTL lapses, and concurrent callers now share one in-flight token request.

vite.config.mts reads env via loadEnv, so the proxy targets documented in .env.example actually apply instead of always taking the hardcoded fallback. Renamed VITE_MOCK_API_URL to VITE_JPMC_MOCK_API_URL - it was one letter from VITE_MOCKED_API_URL, a different tier - and declared it in vite-env.d.ts.


