### PR TITLE
Add CI workflow and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/app/client"
+    schedule:
+      interval: "weekly"
+    groups:
+      client-patch:
+        update-types:
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/app/server"
+    schedule:
+      interval: "weekly"
+    groups:
+      server-patch:
+        update-types:
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  pull_request:
+    paths:
+      - "app/client/**"
+      - "app/server/**"
+      - ".github/workflows/**"
+  push:
+    branches: [main]
+    paths:
+      - "app/client/**"
+      - "app/server/**"
+      - ".github/workflows/**"
+
+jobs:
+  client:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app/client
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20.19.0"
+
+      - run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Test
+        run: pnpm test:no-watch
+
+      - name: Build
+        run: pnpm build
+
+  server:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app/server
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Import smoke test
+        run: node -e "require('./app.js')"


### PR DESCRIPTION
## Summary
- No CI test workflow existed at all in this repo. The single check on the recent vitest dependabot PR (#78) was AWS Amplify's own preview-deploy webhook, not a test run - it was merged on changelog review with nothing actually executing the test suite.
- `ci.yml`: `client` job runs `pnpm test:no-watch` + `pnpm build`; `server` job runs an import smoke test (`require('./app.js')` - no `.listen()` call, so it's side-effect-free).
- Lint is intentionally omitted from both jobs: `app/client` and `app/server`'s `lint`/eslint setups are already broken independent of this change (ESLint 9+ needs `eslint.config.js`; both still have legacy `.eslintrc.js`). That's a separate fix, not bundled in here - happy to follow up with it if wanted.
- `dependabot.yml`: weekly grouped patch updates for both npm directories plus `github-actions`, matching the pattern just added to `pdp-mcp`.

## Test plan
- [x] `app/client`: `pnpm install`, `pnpm test:no-watch` (6 passed), `pnpm build` all succeed locally
- [x] `app/server`: all files pass `node --check`; `require('./app.js')` succeeds with dependencies installed
- [ ] CI workflow runs green on this PR itself

## Note
GitHub flagged 87 existing Dependabot vulnerability alerts on `main` (2 critical, 53 high, 26 moderate, 6 low) when pushing this branch - unrelated to this PR, but worth a look separately.